### PR TITLE
Handle Ignored Errors with a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ rescue CB2::BreakerOpen
 end
 ```
 
+### Custom-Handling Errors
+You may not want certains errors to count towards the circuit opening.
+
+To do so, add an entry to the hash table in the `handle` options, where the key is the class of the error to be handled, and the value is a function that accepts an error as a parameter, and returns `true` if it should be processed, `false` otherwise.
+
+```ruby
+breaker = CB2::Breaker.new(
+  service: "aws"       # identify each circuit breaker individually
+  duration: 60,        # keep track of errors over a 1 min window
+  threshold: 5,        # open the circuit breaker when error rate is at 5%
+  reenable_after: 600, # keep it open for 10 mins
+  redis: Redis.new,    # redis connection it should use to keep state
+  handle: { RuntimeError => Proc.new { |e| e.message == 'foo' } })
+```
+
 ### Circuit breaker stub
 
 CB2 can also run as a stub. Use it to aid testing, simulations and gradual rollouts:

--- a/spec/breaker_spec.rb
+++ b/spec/breaker_spec.rb
@@ -19,14 +19,44 @@ describe CB2::Breaker do
       assert_equal 42, breaker.run { 42 }
     end
 
-    context "breaker has RuntimeErrors ignored" do
+    context "breaker has an error being handled first" do
       let(:breaker) do
         CB2::Breaker.new(service: "aws",
           duration: 60,
           threshold: 5,
           reenable_after: 600,
           redis: MockRedis.new,
-          ignore: [RuntimeError])
+          handle: { RuntimeError => Proc.new { |e|  e.message == 'foo' }})
+      end
+
+      it "does not count a class whose handle function returns false" do
+        6.times {
+          begin
+            breaker.run { raise 'sample-runtime-error' }
+          rescue
+          end
+        }
+        assert_equal 42, breaker.run { 42 }
+      end
+
+      it "counts a class whose handle function returns true" do
+        6.times {
+          begin
+            breaker.run { raise 'foo' }
+          rescue
+          end
+        }
+        assert_raises(CB2::BreakerOpen) do breaker.run { 42 } end
+      end
+
+      it "counts a class that does not have a handle function defined" do
+        6.times {
+          begin
+            breaker.run { 1 / 0 }
+          rescue
+          end
+        }
+        assert_raises(CB2::BreakerOpen) do breaker.run { 42 } end
       end
 
       it "ignores the error classes specified by the user" do
@@ -37,19 +67,6 @@ describe CB2::Breaker do
           end
         }
         assert_equal 42, breaker.run { 42 }
-      end
-
-      it "processes errors not ignored" do
-        5.times {
-          begin
-            breaker.run { raise StandardError.new('sample-standard-error') }
-          rescue
-          end
-        }
-
-        assert_raises(CB2::BreakerOpen) do
-          breaker.run { 2 }
-        end
       end
     end
   end


### PR DESCRIPTION
This is a similar approach to the other PR. The two will likely end up being mutually exclusive. This offers similar features, in a different way.

This will change the current behaviour for ignoring errors. Instead of users providing an array of classes of errors to be ignored, they provide a hash table, where the key is the class to be ignored, and the value is a  function that accepts an error and returns `true` or `false` as to whether the error should be processed.

This approach also does not offer the ability for the user not to raise a certain error from the CB. This kind of check will be left up to the user's code around the circuit breaker's implementation.

cc @ranierorusso 
